### PR TITLE
Firefox release fixes

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
   "name": "Save Pinned Tabs",
   "short_name": "Save Pinned",
-  "version": "1.0.5",
+  "version": "1.1.0",
 
   "browser_specific_settings": {
     "gecko": {

--- a/manifest.json
+++ b/manifest.json
@@ -7,7 +7,7 @@
   "browser_specific_settings": {
     "gecko": {
       "id": "savepinnedtabs@buildyourweb.app",
-      "strict_min_version": "42.0"
+      "strict_min_version": "57.0"
     }
   },
 


### PR DESCRIPTION
Prepare for submission to Firefox Add-on Developer Hub.

- Bump minimum firefox version to match features used in manifest (57).
- Bump extension version to 1.1.0