### PR TITLE
Fix autoloading chrome

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,19 +1,8 @@
 // autoloading tab set
 browser.storage.local.clear();
 
-var listener = function (win) {
-    console.log('Listener activated');
-    browser.windows.getAll(null).then(function (wins) {
-        if (wins.length < 2 && win.type === 'normal') {
-            Sets.autoLoad(win.id);
-        }
+browser.runtime.onStartup.addListener(function () {
+    browser.windows.getCurrent().then(function (win) {
+        Sets.autoLoad(win.id);
     });
-}
-
-// will this always fire at start
-browser.windows.getCurrent().then(function (win) {
-    Sets.autoLoad(win.id);
-    
-    browser.windows.onCreated.removeListener(listener);
-    browser.windows.onCreated.addListener(listener);
 });

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
   "name": "Save Pinned Tabs",
   "short_name": "Save Pinned",
-  "version": "1.1.0",
+  "version": "1.1.1",
 
   "browser_specific_settings": {
     "gecko": {


### PR DESCRIPTION
Refactor autoloading to execute on `runtime.onStartup` event, rather than `window.onCreated` event.

The `window.onCreated` event was unreliable in Firefox, as it would only fire on subsequent windows, and even then it was inconsistent. I will need to investigate further how to make it fire inconsistently when we eventually implement #8.

The `runtime.onStartup` event fires consistently in Firefox, and Chrome, and only fires upon the initial extension startup, removing the need for additional logic to check if the new window created on `window.onCreated` is the initial window or a secondary window.

I hope this will be a simpler and more robust cross-platform implementation. 